### PR TITLE
Update React rendering to use createRoot() instead of ReactDOM.render()

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import './App.css';
 import App from './App';
+import { createRoot } from 'react-dom/client';
  
-ReactDOM.render(
-   <React.StrictMode>
-      <App />
-   </React.StrictMode>,
-   document.getElementById('root')
+
+
+createRoot(document.getElementById('root')).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>
 );


### PR DESCRIPTION
Replaced the use of ReactDOM.render() with createRoot() in the React application to ensure compatibility with React 18 and provide improvements for Concurrent Mode. This change improves the rendering performance and is recommended for all React applications using version 18 or higher.